### PR TITLE
Test other pre-installed package managers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  tmp:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install hello
+
   test:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If someone changes the binary, the SHA will change and your CI will fail.
 The `--gh-token` is optional but recommended inside GitHub Actions because otherwise this tool might be rate limited when determining which assets are available in the release.
 The limit is 60 requests per hour per IP address.
 Normal GitHub Actions such as 
+
 ```yml
 - uses: JamesIves/github-pages-deploy-action@v4
 ```


### PR DESCRIPTION
igankevich on Reddit makes a good point that `cargo install jas` really isn't so safe (https://www.reddit.com/r/rust/comments/1jsob0f/comment/mlo5395/).

So this PR tests what other package managers are available in GitHub Runners. See also https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md.

