### PR TITLE
Support multiple `archive_filename`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 **/target
 tmp*
 tests/cargo-deny*
+tests/ffmpeg*
+tests/ffprobe*
 tests/just*
 tests/no_guess_typos*
 tests/pandoc*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2025-04-07
 
 ### Changed
 
 - Renamed `--binary-filename` to `--executable-filename` ([#20](https://github.com/rikhuijzer/jas/pull/20))
+
+### Fixed
+
+- Fix Pandoc installation and a related path bug ([#20](https://github.com/rikhuijzer/jas/pull/20))
 
 ## [0.2.0] - 2025-04-04
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -280,9 +280,9 @@ fn copy_from_archive(dir: &Path, archive_dir: &Path, args: &InstallArgs, name: &
         let src = crate::guess::guess_executable_in_archive(&files, name);
         let dst = if let Some(executable_filenames) = &args.executable_filename {
             if executable_filenames.len() != 1 {
-                abort(&format!(
+                abort(
                     "Multiple `executable_filename`s can only be specified with multiple `archive_filename`s"
-                ));
+                );
             }
             dir.join(executable_filenames[0].clone())
         } else {

--- a/src/install.rs
+++ b/src/install.rs
@@ -302,7 +302,6 @@ fn copy_from_archive(dir: &Path, archive_dir: &Path, args: &InstallArgs, name: &
 }
 
 fn download_file_core(url: &str) -> Result<Vec<u8>, String> {
-    tracing::info!("Downloading {}", url);
     let mut response = match ureq::get(url).call() {
         Ok(response) => response,
         Err(e) => return Err(format!("Error downloading {url}: {e}")),
@@ -316,6 +315,7 @@ fn download_file_core(url: &str) -> Result<Vec<u8>, String> {
 }
 
 pub(crate) fn download_file(url: &str) -> Vec<u8> {
+    tracing::info!("Downloading {}", url);
     // Manual retry logic since ureq "3.x has no built-in retries".
     let retries = 3;
     for i in 0..retries {

--- a/src/install.rs
+++ b/src/install.rs
@@ -288,6 +288,7 @@ fn copy_from_archive(dir: &Path, archive_dir: &Path, args: &InstallArgs, name: &
         } else {
             dir.join(name)
         };
+        let dst = add_exe_if_needed(&dst);
         vec![(src, dst)]
     };
     for (src, dst) in src_dst {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,16 +86,16 @@ pub(crate) struct InstallArgs {
     /// The name of the GitHub release asset to install
     #[arg(long)]
     asset_name: Option<String>,
-    /// The name of the executable after installation
-    ///
-    /// [default: the repo name or guessed from the url]
-    #[arg(long)]
-    executable_filename: Option<String>,
-    /// The name of the binary in the archive
+    /// The name of the binary/binaries in the archive
     ///
     /// [default: use simple heuristic to guess]
     #[arg(long)]
     archive_filename: Option<Vec<String>>,
+    /// The name of the executable/executables after installation
+    ///
+    /// [default: the repo name or guessed from the url]
+    #[arg(long)]
+    executable_filename: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ pub(crate) fn abort(message: &str) -> ! {
     }
 }
 
+static DEFAULT_INSTALL_DIR: &str = "~/.jas/bin";
+
 #[derive(Clone, Debug, Parser)]
 pub(crate) struct InstallArgs {
     /// The GitHub repository to install from
@@ -79,7 +81,7 @@ pub(crate) struct InstallArgs {
     #[arg(long)]
     sha: Option<String>,
     /// The directory to install the binary to
-    #[arg(long, default_value = "~/.jas/bin")]
+    #[arg(long, default_value = DEFAULT_INSTALL_DIR)]
     dir: String,
     /// The name of the GitHub release asset to install
     #[arg(long)]
@@ -96,12 +98,21 @@ pub(crate) struct InstallArgs {
     archive_filename: Option<Vec<String>>,
 }
 
+#[derive(Clone, Debug, Parser)]
+pub(crate) struct ShowArgs {
+    /// Print the default install directory.
+    #[arg(long)]
+    install_dir: bool,
+}
+
 #[derive(Clone, Debug, clap::Subcommand)]
 pub(crate) enum Task {
     /// Compute the SHA-256 hash of a file or a GitHub repository.
     Sha(ShaArgs),
     /// Install a binary from a GitHub repository.
     Install(InstallArgs),
+    /// Show information.
+    Show(ShowArgs),
     /// Print the project's license.
     License,
 }
@@ -150,6 +161,12 @@ fn main() {
         }
         Task::Install(args) => {
             install::run(&args);
+        }
+        Task::Show(args) => {
+            if args.install_dir {
+                let path = install::interpret_path(DEFAULT_INSTALL_DIR);
+                println!("{}", path.display());
+            }
         }
         Task::License => {
             println!("{}", include_str!("../LICENSE"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ pub(crate) struct InstallArgs {
     ///
     /// [default: use simple heuristic to guess]
     #[arg(long)]
-    archive_filename: Option<String>,
+    archive_filename: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, clap::Subcommand)]

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -239,6 +239,10 @@ fn test_install_pandoc() {
 
 #[test]
 fn test_install_ffmpeg_ffprobe() {
+    if cfg!(target_os = "windows") {
+        tracing::warn!("Skipping test on Windows since it will try to find ffmpeg.exe in archive");
+        return;
+    }
     clean_tests_dir("ffmpeg");
     clean_tests_dir("ffprobe");
 

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -238,6 +238,32 @@ fn test_install_pandoc() {
 }
 
 #[test]
+fn test_install_ffmpeg_ffprobe() {
+    clean_tests_dir("ffmpeg");
+    clean_tests_dir("ffprobe");
+
+    // Chose this file because it's relatively small.
+    let url = "https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-6.0.1-armel-static.tar.xz";
+    let mut cmd = bin();
+    cmd.arg("--verbose")
+        .arg("--ansi=false")
+        .arg("install")
+        .arg("--url")
+        .arg(&url)
+        .arg("--dir=tests")
+        .arg("--archive-filename=ffmpeg")
+        .arg("--archive-filename=ffprobe")
+        .arg("--sha=1c2dd0795990796c29d0da8b0842e0bb13daf35eee062087a78cd70131301d58")
+        .assert()
+        .success();
+
+    let path = std::path::Path::new("tests/ffmpeg");
+    assert!(path.exists());
+    let path = std::path::Path::new("tests/ffprobe");
+    assert!(path.exists());
+}
+
+#[test]
 fn test_install_gh_no_guesses() {
     clean_tests_dir("no_guess_typos");
 

--- a/tests/test_install.rs
+++ b/tests/test_install.rs
@@ -90,7 +90,7 @@ fn test_install_gh_guess_typos() {
         ));
     let path = add_exe_if_needed("tests/typos");
     let path = Path::new(&path);
-    assert!(path.exists());
+    assert!(path.exists(), "path: {path:?}");
 
     let mut version_cmd = Command::new(path);
     version_cmd.arg("--version");


### PR DESCRIPTION
Fixes #16. Now supports:

```sh
jas install \
--url https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-6.0.1-armel-static.tar.xz \
--archive-filename ffmpeg
--archive-filename ffprobe
```
which will install `ffmpeg` and `ffprobe` from the archive.